### PR TITLE
feat: add --complete mode for Ralph workspaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,13 @@
 ### TUI Codebase Patterns
 
 - Entry point: `packages/deep-factor-tui/src/cli.tsx` (meow + ink.render)
+- Headless CLI modes live in `packages/deep-factor-tui/src/print.ts` and `packages/deep-factor-tui/src/complete.ts`, and they should share provider/tool setup through `packages/deep-factor-tui/src/agent-runner.ts`
 - App shell: `packages/deep-factor-tui/src/app.tsx` (<Static> for header/messages scrollback + <LiveSection> for active UI)
 - Agent hook: `packages/deep-factor-tui/src/hooks/useAgent.ts` (React state bridge)
 - Text input hook: `packages/deep-factor-tui/src/hooks/useTextInput.ts` (cursor input handling)
 - Components: `packages/deep-factor-tui/src/components/` (Header, LiveSection, MessageBubble, ToolCallBlock, InputBar, StatusLine)
 - Bash tool: `packages/deep-factor-tui/src/tools/bash.ts` (createBashTool factory, --sandbox flag: workspace|local|docker)
+- Completion mode resolves a Ralph workspace from `--complete-dir`, runs the agent from that workspace's parent directory, and prefers `CLAUDE.md` for the Claude provider or `PROMPT.md`/`prompt.md` for other providers
 - TUI types: `packages/deep-factor-tui/src/types.ts` (TuiAppProps, ChatMessage, AgentStatus)
 - Tests: `packages/deep-factor-tui/__tests__/` (components, integration, e2e)
 

--- a/packages/deep-factor-tui/README.md
+++ b/packages/deep-factor-tui/README.md
@@ -77,6 +77,8 @@ Options
   --mode           Execution mode: plan, approve, yolo (default: yolo)
   --sandbox, -s    Sandbox mode: workspace (default), local, docker
   --print, -p      Non-interactive print mode (output answer to stdout)
+  --complete       Non-interactive completion mode (load workflow from .ralph)
+  --complete-dir   Target Ralph workspace directory (default: ./.ralph)
 ```
 
 ### Examples
@@ -100,6 +102,12 @@ deepfactor
 # Print mode — non-interactive, outputs answer to stdout
 deepfactor -p "What is 2+2?"
 
+# Completion mode — non-interactive, loads prompt/state from ./.ralph
+deepfactor --complete
+
+# Target a package-local Ralph workspace without changing directories
+deepfactor --complete --complete-dir packages/deep-factor-tui/.ralph
+
 # Claude CLI provider using existing CLI auth
 deepfactor --provider claude -p "Reply with exactly: hello"
 
@@ -112,6 +120,22 @@ deepfactor -p -s local "List files in the current directory"
 # Pipe stdin in print mode
 cat PROMPT.md | deepfactor -p
 ```
+
+### Completion mode
+
+`--complete` is a headless workflow for Ralph-style workspaces. It does not accept a positional prompt. Instead, the CLI:
+
+1. Resolves the Ralph workspace from `--complete-dir` or `./.ralph`
+2. Creates `prd.json` and `progress.txt` if they are missing
+3. Validates that `prd.json` contains valid JSON
+4. Loads the workflow prompt from the Ralph workspace and runs the agent from the workspace parent directory
+
+Prompt resolution is explicit:
+
+- With `--provider claude`, the CLI prefers `CLAUDE.md`, then `PROMPT.md`, then `prompt.md`
+- With other providers, the CLI prefers `PROMPT.md`, then `prompt.md`, then `CLAUDE.md`
+
+If `prd.json.example` exists in the Ralph workspace, it is copied to `prd.json` on first run. Otherwise the CLI creates a minimal JSON stub. `progress.txt` is initialized with a Ralph progress header and then reused on later runs.
 
 ## Architecture
 

--- a/packages/deep-factor-tui/__tests__/cli-e2e.test.ts
+++ b/packages/deep-factor-tui/__tests__/cli-e2e.test.ts
@@ -41,10 +41,12 @@ describe("CLI e2e", () => {
     expect(result.stderr).toContain("requires a prompt");
   });
 
-  it("--help outputs usage text with --print, --sandbox, and codex provider help", async () => {
+  it("--help outputs usage text with --print, --complete, --complete-dir, and codex provider help", async () => {
     const result = await run(["--help"]);
     const output = result.stdout + result.stderr;
     expect(output).toContain("--print");
+    expect(output).toContain("--complete");
+    expect(output).toContain("--complete-dir");
     expect(output).toContain("--sandbox");
     expect(output).toContain("langchain, claude, codex");
     expect(output).not.toContain("--parallel");
@@ -76,5 +78,17 @@ describe("CLI e2e", () => {
     expect(result.code).not.toBe(0);
     expect(result.stderr).toContain('Invalid provider "nope"');
     expect(result.stderr).toContain("langchain, claude, codex");
+  });
+
+  it("--complete-dir without --complete exits with a validation error", async () => {
+    const result = await run(["--complete-dir", "packages/deep-factor-tui/.ralph"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("--complete-dir can only be used with --complete");
+  });
+
+  it("--complete rejects a missing completion directory with a clear error", async () => {
+    const result = await run(["--complete", "--complete-dir", "does-not-exist"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("Completion directory does not exist");
   });
 });

--- a/packages/deep-factor-tui/__tests__/complete.test.ts
+++ b/packages/deep-factor-tui/__tests__/complete.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRunHeadlessAgentToCompletion } = vi.hoisted(() => ({
+  mockRunHeadlessAgentToCompletion: vi.fn(),
+}));
+
+vi.mock("../src/agent-runner.js", () => ({
+  runHeadlessAgentToCompletion: mockRunHeadlessAgentToCompletion,
+}));
+
+import {
+  buildCompletePrompt,
+  ensureCompleteStateFiles,
+  resolveCompleteWorkspace,
+  runCompleteMode,
+} from "../src/complete.js";
+
+describe("complete mode", () => {
+  let tempDir: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "deepfactor-complete-"));
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("prefers CLAUDE.md for Claude and PROMPT.md for other providers", () => {
+    const workspaceDir = join(tempDir, ".ralph");
+    mkdirSync(workspaceDir);
+    writeFileSync(join(workspaceDir, "CLAUDE.md"), "Claude prompt");
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Generic prompt");
+    writeFileSync(join(workspaceDir, "prompt.md"), "Lowercase prompt");
+
+    expect(resolveCompleteWorkspace({ provider: "claude", cwd: tempDir }).promptPath).toBe(
+      join(workspaceDir, "CLAUDE.md"),
+    );
+    expect(resolveCompleteWorkspace({ provider: "langchain", cwd: tempDir }).promptPath).toBe(
+      join(workspaceDir, "PROMPT.md"),
+    );
+  });
+
+  it("copies prd.json.example and creates progress.txt when state files are missing", () => {
+    const workspaceDir = join(tempDir, ".ralph");
+    mkdirSync(workspaceDir);
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Ship it");
+    writeFileSync(
+      join(workspaceDir, "prd.json.example"),
+      '{ "project": "demo", "userStories": [] }\n',
+    );
+    const workspace = resolveCompleteWorkspace({ provider: "langchain", cwd: tempDir });
+
+    ensureCompleteStateFiles(workspace);
+
+    expect(readFileSync(workspace.prdPath, "utf8")).toContain('"project": "demo"');
+    expect(readFileSync(workspace.progressPath, "utf8")).toContain("# Ralph Progress Log");
+  });
+
+  it("preserves existing prd.json and progress.txt on rerun", () => {
+    const workspaceDir = join(tempDir, ".ralph");
+    mkdirSync(workspaceDir);
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Ship it");
+    writeFileSync(join(workspaceDir, "prd.json"), '{ "project": "keep-me", "userStories": [] }\n');
+    writeFileSync(join(workspaceDir, "progress.txt"), "existing progress\n");
+    const workspace = resolveCompleteWorkspace({ provider: "langchain", cwd: tempDir });
+
+    ensureCompleteStateFiles(workspace);
+
+    expect(readFileSync(workspace.prdPath, "utf8")).toContain('"keep-me"');
+    expect(readFileSync(workspace.progressPath, "utf8")).toBe("existing progress\n");
+  });
+
+  it("rejects invalid prd.json content", () => {
+    const workspaceDir = join(tempDir, ".ralph");
+    mkdirSync(workspaceDir);
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Ship it");
+    writeFileSync(join(workspaceDir, "prd.json"), "{ nope");
+    const workspace = resolveCompleteWorkspace({ provider: "langchain", cwd: tempDir });
+
+    expect(() => ensureCompleteStateFiles(workspace)).toThrow(/Invalid prd\.json/);
+  });
+
+  it("runs from the completion workspace parent directory and prints the final response", async () => {
+    const workspaceDir = join(tempDir, "packages", "demo", ".ralph");
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Implement the requested change.");
+    mockRunHeadlessAgentToCompletion.mockResolvedValueOnce({
+      response: "<promise>COMPLETE</promise>",
+      stopReason: "completed",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      iterations: 1,
+    });
+
+    await expect(
+      runCompleteMode({
+        provider: "langchain",
+        model: "gpt-4.1-mini",
+        maxIter: 10,
+        sandbox: "workspace",
+        mode: "yolo",
+        completeDir: workspaceDir,
+      }),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockRunHeadlessAgentToCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: dirname(workspaceDir),
+        provider: "langchain",
+        model: "gpt-4.1-mini",
+      }),
+    );
+    expect(mockRunHeadlessAgentToCompletion.mock.calls[0][0].prompt).toContain(".ralph/prd.json");
+    expect(mockRunHeadlessAgentToCompletion.mock.calls[0][0].prompt).toContain(
+      "Implement the requested change.",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith("<promise>COMPLETE</promise>");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("builds the prompt with explicit same-directory guidance", () => {
+    const workspaceDir = join(tempDir, ".ralph");
+    mkdirSync(workspaceDir);
+    writeFileSync(join(workspaceDir, "PROMPT.md"), "Follow the workflow.");
+    writeFileSync(join(workspaceDir, "prd.json"), '{ "userStories": [] }\n');
+    writeFileSync(join(workspaceDir, "progress.txt"), "log\n");
+    const workspace = resolveCompleteWorkspace({ provider: "langchain", cwd: tempDir });
+
+    const prompt = buildCompletePrompt(workspace);
+
+    expect(prompt).toContain("If the workflow prompt refers to files in the same directory");
+    expect(prompt).toContain(".ralph/progress.txt");
+    expect(prompt).toContain("Follow the workflow.");
+  });
+});

--- a/packages/deep-factor-tui/src/agent-runner.ts
+++ b/packages/deep-factor-tui/src/agent-runner.ts
@@ -1,0 +1,66 @@
+import { createDeepFactorAgent, isPendingResult, maxIterations } from "deep-factor-agent";
+import type { AgentMode, AgentResult, PendingResult, PlanResult } from "deep-factor-agent";
+import { createBashTool, type SandboxMode } from "./tools/bash.js";
+import { resolveProviderModel } from "./provider-resolution.js";
+import type { ProviderType } from "./types.js";
+
+export interface HeadlessAgentRunOptions {
+  prompt: string;
+  provider: ProviderType;
+  model: string;
+  maxIter: number;
+  sandbox: SandboxMode;
+  mode: AgentMode;
+  cwd?: string;
+}
+
+type HeadlessAgentResult = AgentResult | PendingResult | PlanResult;
+
+async function withWorkingDirectory<T>(cwd: string | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!cwd || cwd === process.cwd()) {
+    return fn();
+  }
+
+  const originalCwd = process.cwd();
+  process.chdir(cwd);
+
+  try {
+    return await fn();
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+export async function runHeadlessAgent(
+  options: HeadlessAgentRunOptions,
+): Promise<HeadlessAgentResult> {
+  const { prompt, provider, model, maxIter, sandbox, mode, cwd } = options;
+
+  return withWorkingDirectory(cwd, async () => {
+    const tools = [createBashTool(sandbox)];
+    const resolvedModel = resolveProviderModel({ provider, model, mode });
+
+    const agent = createDeepFactorAgent({
+      model: resolvedModel,
+      tools,
+      stopWhen: [maxIterations(maxIter)],
+      interruptOn: [],
+      parallelToolCalls: true,
+      mode,
+    });
+
+    return agent.loop(prompt);
+  });
+}
+
+export async function runHeadlessAgentToCompletion(
+  options: HeadlessAgentRunOptions,
+): Promise<HeadlessAgentResult> {
+  const result = await runHeadlessAgent(options);
+
+  if (isPendingResult(result) && options.mode === "plan") {
+    return result.resume({ decision: "approve" });
+  }
+
+  return result;
+}

--- a/packages/deep-factor-tui/src/cli.tsx
+++ b/packages/deep-factor-tui/src/cli.tsx
@@ -25,6 +25,8 @@ const cli = meow(
     --mode           Execution mode: plan, approve, yolo (default: yolo)
     --sandbox, -s    Sandbox mode: workspace (default), local, docker
     --print, -p      Non-interactive print mode (output answer to stdout)
+    --complete       Non-interactive completion mode (load workflow from .ralph)
+    --complete-dir   Target Ralph workspace directory (default: ./.ralph)
     --resume, -r     Resume a previous session (optionally pass session ID)
 
   Examples
@@ -36,6 +38,8 @@ const cli = meow(
     $ deepfactor --provider claude -p "What is 2+2?"
     $ deepfactor --provider codex -p "What is 2+2?"
     $ deepfactor -p "List files in the current directory"
+    $ deepfactor --complete
+    $ deepfactor --complete --complete-dir packages/deep-factor-tui/.ralph
     $ deepfactor -s local "Run system commands"
     $ cat PROMPT.md | deepfactor -p
     $ deepfactor --resume
@@ -69,6 +73,13 @@ const cli = meow(
         type: "boolean",
         shortFlag: "p",
         default: false,
+      },
+      complete: {
+        type: "boolean",
+        default: false,
+      },
+      completeDir: {
+        type: "string",
       },
       resume: {
         type: "string",
@@ -110,6 +121,37 @@ let provider = providerFlag ?? DEFAULT_PROVIDER;
 let model = cli.flags.model ?? DEFAULT_MODELS[provider];
 
 let prompt = cli.input.join(" ") || undefined;
+
+if (cli.flags.completeDir && !cli.flags.complete) {
+  process.stderr.write("Error: --complete-dir can only be used with --complete.\n");
+  process.exit(1);
+}
+
+if (cli.flags.complete && cli.flags.print) {
+  process.stderr.write("Error: --complete cannot be used together with --print.\n");
+  process.exit(1);
+}
+
+if (cli.flags.complete && prompt) {
+  process.stderr.write("Error: --complete does not accept a prompt argument.\n");
+  process.exit(1);
+}
+
+if (cli.flags.complete) {
+  if (provider === "langchain") {
+    loadEnv();
+  }
+
+  const { runCompleteMode } = await import("./complete.js");
+  await runCompleteMode({
+    provider,
+    model,
+    maxIter: cli.flags.maxIter,
+    sandbox: sandboxMode,
+    mode,
+    completeDir: cli.flags.completeDir,
+  });
+}
 
 if (cli.flags.print) {
   // Print mode: non-interactive, headless agent

--- a/packages/deep-factor-tui/src/complete.ts
+++ b/packages/deep-factor-tui/src/complete.ts
@@ -1,0 +1,161 @@
+import { copyFileSync, existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { isPlanResult } from "deep-factor-agent";
+import type { AgentMode } from "deep-factor-agent";
+import type { SandboxMode } from "./tools/bash.js";
+import { runHeadlessAgentToCompletion } from "./agent-runner.js";
+import type { ProviderType } from "./types.js";
+
+export interface CompleteModeOptions {
+  provider: ProviderType;
+  model: string;
+  maxIter: number;
+  sandbox: SandboxMode;
+  mode: AgentMode;
+  completeDir?: string;
+}
+
+export interface CompleteWorkspace {
+  workspaceDir: string;
+  projectDir: string;
+  promptPath: string;
+  prdPath: string;
+  progressPath: string;
+}
+
+const DEFAULT_COMPLETE_DIR = ".ralph";
+const DEFAULT_PRD_TEMPLATE = {
+  project: "",
+  branchName: "",
+  description: "",
+  userStories: [],
+};
+
+function formatPromptPath(targetPath: string, projectDir: string): string {
+  const relativePath = relative(projectDir, targetPath);
+  return relativePath && !relativePath.startsWith("..") ? relativePath : targetPath;
+}
+
+export function resolveCompleteWorkspace(args: {
+  completeDir?: string;
+  provider: ProviderType;
+  cwd?: string;
+}): CompleteWorkspace {
+  const cwd = args.cwd ?? process.cwd();
+  const workspaceDir = resolve(cwd, args.completeDir ?? DEFAULT_COMPLETE_DIR);
+
+  if (!existsSync(workspaceDir)) {
+    throw new Error(`Completion directory does not exist: ${workspaceDir}`);
+  }
+
+  if (!statSync(workspaceDir).isDirectory()) {
+    throw new Error(`Completion directory is not a directory: ${workspaceDir}`);
+  }
+
+  const promptCandidates =
+    args.provider === "claude"
+      ? ["CLAUDE.md", "PROMPT.md", "prompt.md"]
+      : ["PROMPT.md", "prompt.md", "CLAUDE.md"];
+  const promptPath = promptCandidates
+    .map((fileName) => join(workspaceDir, fileName))
+    .find((candidate) => existsSync(candidate) && statSync(candidate).isFile());
+
+  if (!promptPath) {
+    throw new Error(
+      `No completion prompt found in ${workspaceDir}. Expected one of: ${promptCandidates.join(", ")}`,
+    );
+  }
+
+  return {
+    workspaceDir,
+    projectDir: dirname(workspaceDir),
+    promptPath,
+    prdPath: join(workspaceDir, "prd.json"),
+    progressPath: join(workspaceDir, "progress.txt"),
+  };
+}
+
+export function ensureCompleteStateFiles(workspace: CompleteWorkspace): void {
+  if (!existsSync(workspace.prdPath)) {
+    const prdExamplePath = join(workspace.workspaceDir, "prd.json.example");
+    if (existsSync(prdExamplePath) && statSync(prdExamplePath).isFile()) {
+      copyFileSync(prdExamplePath, workspace.prdPath);
+    } else {
+      writeFileSync(workspace.prdPath, `${JSON.stringify(DEFAULT_PRD_TEMPLATE, null, 2)}\n`);
+    }
+  }
+
+  const prdRaw = readFileSync(workspace.prdPath, "utf8");
+  try {
+    JSON.parse(prdRaw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid prd.json at ${workspace.prdPath}: ${message}`);
+  }
+
+  if (!existsSync(workspace.progressPath)) {
+    writeFileSync(
+      workspace.progressPath,
+      `# Ralph Progress Log\nStarted: ${new Date().toISOString()}\n---\n`,
+    );
+  }
+}
+
+export function buildCompletePrompt(workspace: CompleteWorkspace): string {
+  const promptBody = readFileSync(workspace.promptPath, "utf8").trimEnd();
+  const promptName = basename(workspace.promptPath);
+  const workspaceLabel = formatPromptPath(workspace.workspaceDir, workspace.projectDir);
+  const prdLabel = formatPromptPath(workspace.prdPath, workspace.projectDir);
+  const progressLabel = formatPromptPath(workspace.progressPath, workspace.projectDir);
+
+  return [
+    "You are running in deepfactor completion mode.",
+    `Project working directory: ${workspace.projectDir}`,
+    `Completion workspace: ${workspace.workspaceDir}`,
+    `Workflow prompt source: ${promptName}`,
+    `Use the Ralph state files at ${prdLabel} and ${progressLabel}.`,
+    `If the workflow prompt refers to files in the same directory as the prompt, resolve them inside ${workspaceLabel}.`,
+    "",
+    promptBody,
+  ].join("\n");
+}
+
+export async function runCompleteMode(options: CompleteModeOptions): Promise<void> {
+  try {
+    const workspace = resolveCompleteWorkspace({
+      completeDir: options.completeDir,
+      provider: options.provider,
+    });
+    ensureCompleteStateFiles(workspace);
+
+    const finalResult = await runHeadlessAgentToCompletion({
+      prompt: buildCompletePrompt(workspace),
+      provider: options.provider,
+      model: options.model,
+      maxIter: options.maxIter,
+      sandbox: options.sandbox,
+      mode: options.mode,
+      cwd: workspace.projectDir,
+    });
+
+    if (finalResult.stopReason === "human_input_needed") {
+      process.stderr.write(
+        "Error: Agent requested human input in non-interactive completion mode.\n",
+      );
+      process.exit(1);
+    }
+
+    if (finalResult.stopReason === "max_errors") {
+      const detail = finalResult.stopDetail ?? "Agent stopped due to repeated errors";
+      process.stderr.write(`Error: ${detail}\n`);
+      process.exit(1);
+    }
+
+    process.stdout.write(isPlanResult(finalResult) ? finalResult.plan : finalResult.response);
+    process.exit(0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/deep-factor-tui/src/print.ts
+++ b/packages/deep-factor-tui/src/print.ts
@@ -1,12 +1,7 @@
-import {
-  createDeepFactorAgent,
-  maxIterations,
-  isPlanResult,
-  isPendingResult,
-} from "deep-factor-agent";
-import type { AgentResult, PendingResult, PlanResult, AgentMode } from "deep-factor-agent";
-import { createBashTool, type SandboxMode } from "./tools/bash.js";
-import { resolveProviderModel } from "./provider-resolution.js";
+import { isPlanResult } from "deep-factor-agent";
+import type { AgentMode } from "deep-factor-agent";
+import type { SandboxMode } from "./tools/bash.js";
+import { runHeadlessAgentToCompletion } from "./agent-runner.js";
 import type { ProviderType } from "./types.js";
 
 export interface PrintModeOptions {
@@ -22,25 +17,14 @@ export async function runPrintMode(options: PrintModeOptions): Promise<void> {
   const { prompt, provider, model, maxIter, sandbox, mode } = options;
 
   try {
-    const tools = [createBashTool(sandbox)];
-    const resolvedModel = resolveProviderModel({ provider, model, mode });
-
-    const agent = createDeepFactorAgent({
-      model: resolvedModel,
-      tools,
-      stopWhen: [maxIterations(maxIter)],
-      interruptOn: [],
-      parallelToolCalls: true,
+    const finalResult = await runHeadlessAgentToCompletion({
+      prompt,
+      provider,
+      model,
+      maxIter,
+      sandbox,
       mode,
     });
-
-    const result: AgentResult | PendingResult | PlanResult = await agent.loop(prompt);
-
-    // Plan mode now returns PendingResult — auto-approve in non-interactive print mode
-    let finalResult: AgentResult | PendingResult | PlanResult = result;
-    if (isPendingResult(finalResult) && mode === "plan") {
-      finalResult = await finalResult.resume({ decision: "approve" });
-    }
 
     if (finalResult.stopReason === "human_input_needed") {
       process.stderr.write("Error: Agent requested human input in non-interactive print mode.\n");


### PR DESCRIPTION
## Summary
- add a first-class `--complete` CLI mode with `--complete-dir` workspace targeting
- initialize and validate Ralph state files, resolve provider-specific prompt files, and run headless completion from the workspace parent directory
- share headless agent execution between print and completion modes, and add docs plus test coverage for the new workflow

## Testing
- pnpm -r build
- pnpm -r test
- pnpm -r type-check

Closes #16